### PR TITLE
Add theme provider support and align contact details

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ npm install
 npm run dev
 ```
 
-Die Website ist dann unter `http://localhost:8080` erreichbar.
+Die Website ist dann unter `http://localhost:5173` erreichbar.
 
 ### Build für Produktion
 ```bash

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build": "vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
+    "test": "node scripts/run-tests.mjs",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -1,0 +1,54 @@
+import { build } from "esbuild";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+
+const entry = resolve("tests/contact-schema.test.ts");
+const tempDir = mkdtempSync(join(tmpdir(), "contact-tests-"));
+const outfile = join(tempDir, "contact-schema.test.mjs");
+
+await build({
+  entryPoints: [entry],
+  outfile,
+  bundle: true,
+  platform: "node",
+  format: "esm",
+  target: "node18",
+  sourcemap: "inline",
+  define: {
+    "process.env.NODE_ENV": '"test"',
+  },
+});
+
+try {
+  const module = await import(pathToFileURL(outfile).href);
+  if (typeof module.run !== "function") {
+    throw new Error("Test module does not export a run function");
+  }
+
+  const results = await module.run();
+  let failed = 0;
+
+  for (const result of results) {
+    if (result.passed) {
+      console.log(`✔ ${result.name}`);
+    } else {
+      failed += 1;
+      console.error(`✖ ${result.name}`);
+      if (result.error instanceof Error) {
+        console.error(result.error.stack);
+      } else if (result.error !== undefined) {
+        console.error(result.error);
+      }
+    }
+  }
+
+  if (failed > 0) {
+    process.exitCode = 1;
+  } else {
+    console.log(`\n${results.length} tests passed.`);
+  }
+} finally {
+  rmSync(tempDir, { recursive: true, force: true });
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { Toaster as Sonner } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
+import { ThemeProvider } from "@/components/theme-provider";
 import Navigation from "./components/Navigation";
 import Footer from "./components/Footer";
 import Home from "./pages/Home";
@@ -22,27 +23,29 @@ const App = () => {
   const basename = isGithubPages ? "/birgitshair-web-revamp" : "";
   
   return (
-    <QueryClientProvider client={queryClient}>
-      <TooltipProvider>
-        <Toaster />
-        <Sonner />
-        <BrowserRouter basename={basename}>
-        <Navigation />
-        <Routes>
-          <Route path="/" element={<Home />} />
-          <Route path="/leistungen" element={<Leistungen />} />
-          <Route path="/team" element={<Team />} />
-          <Route path="/galerie" element={<Galerie />} />
-          <Route path="/preise" element={<Preise />} />
-          <Route path="/kontakt" element={<Kontakt />} />
-          <Route path="/impressum" element={<Impressum />} />
-          <Route path="/datenschutz" element={<Datenschutz />} />
-          <Route path="*" element={<NotFound />} />
-        </Routes>
-        <Footer />
-      </BrowserRouter>
-    </TooltipProvider>
-  </QueryClientProvider>
+    <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+      <QueryClientProvider client={queryClient}>
+        <TooltipProvider>
+          <Toaster />
+          <Sonner />
+          <BrowserRouter basename={basename}>
+            <Navigation />
+            <Routes>
+              <Route path="/" element={<Home />} />
+              <Route path="/leistungen" element={<Leistungen />} />
+              <Route path="/team" element={<Team />} />
+              <Route path="/galerie" element={<Galerie />} />
+              <Route path="/preise" element={<Preise />} />
+              <Route path="/kontakt" element={<Kontakt />} />
+              <Route path="/impressum" element={<Impressum />} />
+              <Route path="/datenschutz" element={<Datenschutz />} />
+              <Route path="*" element={<NotFound />} />
+            </Routes>
+            <Footer />
+          </BrowserRouter>
+        </TooltipProvider>
+      </QueryClientProvider>
+    </ThemeProvider>
   );
 };
 

--- a/src/components/theme-provider.tsx
+++ b/src/components/theme-provider.tsx
@@ -1,0 +1,8 @@
+import { ThemeProvider as NextThemesProvider } from "next-themes";
+import type { ThemeProviderProps } from "next-themes/dist/types";
+
+const ThemeProvider = ({ children, ...props }: ThemeProviderProps) => {
+  return <NextThemesProvider {...props}>{children}</NextThemesProvider>;
+};
+
+export { ThemeProvider };

--- a/src/lib/contact-schema.ts
+++ b/src/lib/contact-schema.ts
@@ -1,0 +1,30 @@
+import { z } from "zod";
+
+export const contactSchema = z.object({
+  name: z
+    .string()
+    .trim()
+    .min(1, { message: "Name ist erforderlich" })
+    .max(100, { message: "Name darf maximal 100 Zeichen lang sein" })
+    .regex(/^[a-zA-ZäöüÄÖÜß\s\-']+$/, { message: "Name enthält ungültige Zeichen" }),
+  email: z
+    .string()
+    .trim()
+    .min(1, { message: "E-Mail ist erforderlich" })
+    .email({ message: "Ungültige E-Mail-Adresse" })
+    .max(255, { message: "E-Mail darf maximal 255 Zeichen lang sein" }),
+  phone: z
+    .string()
+    .trim()
+    .max(30, { message: "Telefonnummer darf maximal 30 Zeichen lang sein" })
+    .regex(/^[-0-9\s()+/]*$/, { message: "Telefonnummer enthält ungültige Zeichen" })
+    .optional()
+    .or(z.literal("")),
+  message: z
+    .string()
+    .trim()
+    .min(1, { message: "Nachricht ist erforderlich" })
+    .max(1000, { message: "Nachricht darf maximal 1000 Zeichen lang sein" }),
+});
+
+export type ContactFormData = z.infer<typeof contactSchema>;

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -153,7 +153,7 @@ const Home = () => {
               variant="outline"
               className="border-primary-foreground text-primary-foreground hover:bg-primary-foreground hover:text-primary"
             >
-              <a href="tel:+4993170096040">0931 700 960 40</a>
+              <a href="tel:+499316606888">0931/6606888</a>
             </Button>
           </div>
         </div>

--- a/src/pages/Kontakt.tsx
+++ b/src/pages/Kontakt.tsx
@@ -6,35 +6,8 @@ import { Label } from "@/components/ui/label";
 import { Card } from "@/components/ui/card";
 import { useToast } from "@/hooks/use-toast";
 import { MapPin, Phone, Mail, Clock } from "lucide-react";
-import { z } from "zod";
-
-// Validation schema with security measures
-const contactSchema = z.object({
-  name: z
-    .string()
-    .trim()
-    .min(1, { message: "Name ist erforderlich" })
-    .max(100, { message: "Name darf maximal 100 Zeichen lang sein" })
-    .regex(/^[a-zA-ZäöüÄÖÜß\s\-']+$/, { message: "Name enthält ungültige Zeichen" }),
-  email: z
-    .string()
-    .trim()
-    .min(1, { message: "E-Mail ist erforderlich" })
-    .email({ message: "Ungültige E-Mail-Adresse" })
-    .max(255, { message: "E-Mail darf maximal 255 Zeichen lang sein" }),
-  phone: z
-    .string()
-    .trim()
-    .max(30, { message: "Telefonnummer darf maximal 30 Zeichen lang sein" })
-    .regex(/^[0-9\s\+\-\(\)\/]*$/, { message: "Telefonnummer enthält ungültige Zeichen" })
-    .optional()
-    .or(z.literal("")),
-  message: z
-    .string()
-    .trim()
-    .min(1, { message: "Nachricht ist erforderlich" })
-    .max(1000, { message: "Nachricht darf maximal 1000 Zeichen lang sein" }),
-});
+import { contactSchema } from "@/lib/contact-schema";
+import { ZodError } from "zod";
 
 const Kontakt = () => {
   const { toast } = useToast();
@@ -76,7 +49,7 @@ const Kontakt = () => {
       // Reset form after successful validation
       setFormData({ name: "", email: "", phone: "", message: "" });
     } catch (error) {
-      if (error instanceof z.ZodError) {
+      if (error instanceof ZodError) {
         // Map validation errors to form fields
         const fieldErrors: Record<string, string> = {};
         error.errors.forEach((err) => {

--- a/src/pages/Preise.tsx
+++ b/src/pages/Preise.tsx
@@ -143,7 +143,7 @@ const Preise = () => {
               <Link to="/kontakt">Beratungstermin buchen</Link>
             </Button>
             <Button asChild size="lg" variant="outline">
-              <a href="tel:+4993170096040">0931 700 960 40</a>
+              <a href="tel:+499316606888">0931/6606888</a>
             </Button>
           </div>
         </div>

--- a/tests/contact-schema.test.ts
+++ b/tests/contact-schema.test.ts
@@ -1,0 +1,98 @@
+import assert from "node:assert/strict";
+import { contactSchema } from "../src/lib/contact-schema";
+
+type TestCase = {
+  name: string;
+  fn: () => void | Promise<void>;
+};
+
+const tests: TestCase[] = [];
+
+function test(name: string, fn: () => void | Promise<void>) {
+  tests.push({ name, fn });
+}
+
+test("accepts valid contact data", () => {
+  const result = contactSchema.safeParse({
+    name: "Birgit Beispiel",
+    email: "birgit@example.com",
+    phone: "+49 931 6606888",
+    message: "Ich hätte gerne einen Termin nächste Woche.",
+  });
+
+  assert.equal(result.success, true);
+  if (result.success) {
+    assert.equal(result.data.name, "Birgit Beispiel");
+  }
+});
+
+test("rejects empty required fields", () => {
+  const result = contactSchema.safeParse({
+    name: "",
+    email: "",
+    phone: "",
+    message: "",
+  });
+
+  assert.equal(result.success, false);
+  if (!result.success) {
+    const messages = result.error.issues.map((issue) => issue.message);
+    assert(messages.includes("Name ist erforderlich"));
+    assert(messages.includes("E-Mail ist erforderlich"));
+    assert(messages.includes("Nachricht ist erforderlich"));
+  }
+});
+
+test("rejects invalid characters in name", () => {
+  const result = contactSchema.safeParse({
+    name: "<script>",
+    email: "kunde@example.com",
+    phone: "", 
+    message: "Test",
+  });
+
+  assert.equal(result.success, false);
+  if (!result.success) {
+    assert.equal(result.error.issues[0]?.message, "Name enthält ungültige Zeichen");
+  }
+});
+
+test("rejects invalid phone characters", () => {
+  const result = contactSchema.safeParse({
+    name: "Max Mustermann",
+    email: "max@example.com",
+    phone: "0931*6606888",
+    message: "Test",
+  });
+
+  assert.equal(result.success, false);
+  if (!result.success) {
+    assert.equal(result.error.issues[0]?.message, "Telefonnummer enthält ungültige Zeichen");
+  }
+});
+
+test("allows optional phone field", () => {
+  const result = contactSchema.safeParse({
+    name: "Max Mustermann",
+    email: "max@example.com",
+    phone: "",
+    message: "Test",
+  });
+
+  assert.equal(result.success, true);
+});
+
+export async function run() {
+  const results = [] as Array<{ name: string; passed: boolean; error?: unknown }>;
+
+  for (const { name, fn } of tests) {
+    try {
+      await fn();
+      results.push({ name, passed: true });
+    } catch (error) {
+      results.push({ name, passed: false, error });
+    }
+  }
+
+  return results;
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,7 +8,7 @@ export default defineConfig(({ mode }) => ({
   base: mode === "production" ? "/birgitshair-web-revamp/" : "/",
   server: {
     host: "::",
-    port: 8080,
+    port: 5173,
   },
   plugins: [react(), mode === "development" && componentTagger()].filter(Boolean),
   resolve: {


### PR DESCRIPTION
## Summary
- wrap the application with a next-themes ThemeProvider so the Sonner toaster can read the active theme safely
- align CTA phone numbers with the canonical salon contact details and update the documented dev server port
- extract the contact form schema for reuse and add esbuild-driven unit tests covering happy and error paths

## Testing
- npm run test
- npm run lint *(fails: pre-existing lint violations in shadcn-generated UI files and tailwind.config.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68e4d4c1e6dc8333a18ba5ade8b71d39